### PR TITLE
Moving commit QC into log entries

### DIFF
--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -17,7 +17,9 @@ jobs:
         run: wget https://nightly.tlapl.us/dist/tla2tools.jar
       - name: Get (nightly) CommunityModules
         run: wget https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar
-      - name: Random simulation with TLC
+      - name: Random simulation with TLC (crash)
+        run: java -Dtlc2.TLC.stopAfter=600 -XX:+UseParallelGC -jar tla2tools.jar -workers auto -simulate SIMpirateship.tla -config SIMpirateshipCrash.cfg
+      - name: Random simulation with TLC (byzantine)
         run: java -Dtlc2.TLC.stopAfter=600 -XX:+UseParallelGC -jar tla2tools.jar -workers auto -simulate SIMpirateship.tla
 
   tlc-verify:

--- a/MCpirateship.cfg
+++ b/MCpirateship.cfg
@@ -22,6 +22,7 @@ INVARIANT
     ByzLogInv
     OneLeaderPerTermInv
     WellFormedLogInv
+    QuorumAgreementInv
 
 PROPERTIES 
     CommittedLogAppendOnlyProp

--- a/MCpirateship.cfg
+++ b/MCpirateship.cfg
@@ -22,7 +22,6 @@ INVARIANT
     ByzLogInv
     OneLeaderPerTermInv
     WellFormedLogInv
-    WellFormedQCsInv
 
 PROPERTIES 
     CommittedLogAppendOnlyProp

--- a/SIMpirateship.cfg
+++ b/SIMpirateship.cfg
@@ -12,7 +12,7 @@ CONSTANT
     R = {a,b,c,Z}
     BR = {Z}
 
-    MaxByzActions = 0
+    MaxByzActions = 2
 
 INVARIANT 
     TypeOK 

--- a/SIMpirateship.cfg
+++ b/SIMpirateship.cfg
@@ -12,7 +12,7 @@ CONSTANT
     R = {a,b,c,Z}
     BR = {Z}
 
-    MaxByzActions = 2
+    MaxByzActions = 0
 
 INVARIANT 
     TypeOK 
@@ -21,7 +21,6 @@ INVARIANT
     ByzLogInv
     OneLeaderPerTermInv
     WellFormedLogInv
-    WellFormedQCsInv
 
 PROPERTIES 
     CommittedLogAppendOnlyProp

--- a/SIMpirateship.cfg
+++ b/SIMpirateship.cfg
@@ -12,7 +12,7 @@ CONSTANT
     R = {a,b,c,Z}
     BR = {Z}
 
-    MaxByzActions = 2
+    MaxByzActions = 0
 
 INVARIANT 
     TypeOK 
@@ -21,6 +21,7 @@ INVARIANT
     ByzLogInv
     OneLeaderPerTermInv
     WellFormedLogInv
+    QuorumAgreementInv
 
 PROPERTIES 
     CommittedLogAppendOnlyProp

--- a/SIMpirateshipCrash.cfg
+++ b/SIMpirateshipCrash.cfg
@@ -1,0 +1,39 @@
+SPECIFICATION Spec
+
+CONSTANT 
+    Timeout <- SIMTimeout
+
+    Txs = {1,2,3,4}
+
+    a = a
+    b = b
+    c = c
+    Z = Z
+    R = {a,b,c,Z}
+    BR = {Z}
+
+    MaxByzActions = 0
+
+INVARIANT 
+    TypeOK 
+    IndexBoundsInv
+    LogInv
+    ByzLogInv
+    OneLeaderPerTermInv
+    WellFormedLogInv
+
+PROPERTIES 
+    CommittedLogAppendOnlyProp
+    ByzCommittedLogAppendOnlyProp
+
+CONSTRAINTS
+    CrashCommitIndexAt1
+    CrashCommitIndexAt2
+    ByzCommitIndexAt1
+    ByzCommitIndexAt2
+
+POSTCONDITION 
+    MonitorPostcondition
+
+_PERIODIC
+    PrintMonitors

--- a/pirateship.tla
+++ b/pirateship.tla
@@ -162,12 +162,12 @@ IsQC(e) ==
 HighestCrashQC(l) ==
     IF l = <<>> THEN 0 ELSE Last(l).crashQC
 
-\* Given a log l, returns the index of the highest log entry with a quorum certificate, 0 if the log contains no QCs
+\* Given a log l, returns the index of the highest log entry with a byzantine QC, 0 if the log contains no QCs
 HighestByzQC(l) ==
     LET idx == SelectLastInSeq(l, IsQC)
     IN IF idx = 0 THEN 0 ELSE Max(l[idx].byzQC)
 
-\* Given a log l, returns the index of the highest log entry with a quorum certificate over a quorum certificate
+\* Given a log l, returns the index of the highest log entry with a byzQC over a byzQC
 HighestQCOverQC(l) ==
     LET lidx == HighestByzQC(l)
         idx == SelectLastInSubSeq(l, 1, lidx, IsQC)

--- a/pirateship.tla
+++ b/pirateship.tla
@@ -184,7 +184,7 @@ MaxQuorum(l, m, default) ==
                  THEN i ELSE RMaxQuorum(i-1)
     IN RMaxQuorum(Len(l))
 
-\* Checks if a log l is well formed e.g. terms are monotonically increasing
+\* Checks if a log l is well formed e.g. views are monotonically increasing
 WellFormedLog(l) ==
     \A i \in DOMAIN l :
         \* check views are monotonically increasing
@@ -542,5 +542,11 @@ IndexBoundsInv ==
 
 WellFormedLogInv ==
     \A r \in CR : WellFormedLog(log[r])
+
+\* Classic CFT safety property - if a log entry is committed on one replica, it is present on crash quorum of replicas
+QuorumAgreementInv ==
+    byzActions = 0 => 
+        \A i \in R: \E q \in CQ: 
+            \A j \in q: IsPrefix(Committed(i), log[j])
 
 ====


### PR DESCRIPTION
CI is failing as the byz commit can front run the crash commit. This is a side effect of having the crash qc (commit index) in the AE messages. This PR moves the crashQC into log entries themselves. 