### PR TITLE
Clear all messages from previous views in a single step.

### DIFF
--- a/pirateship.tla
+++ b/pirateship.tla
@@ -447,9 +447,7 @@ BecomePrimary(r) ==
 \* Note that replicas must always discard messages as the pairwise channels are ordered so a replica may need to discard an out-of-date message to process a more recent one
 DiscardMessages ==
     /\ \E s,r \in R:
-        network' = 
-            [network EXCEPT ![r][s] = 
-                SelectSeq(@, LAMBDA m: ~(m.view < view[r] \/ (m.type = "ViewChange" /\ primary[r])))]
+            network' = [network EXCEPT ![r][s] = SelectSeq(@, LAMBDA m: m.view >= view[r])]
     /\ UNCHANGED <<view, log, primary, prepareQC, crashCommitIndex, byzCommitIndex, byzActions, viewStable>>
 
 ----

--- a/pirateship.tla
+++ b/pirateship.tla
@@ -447,7 +447,7 @@ BecomePrimary(r) ==
 \* Note that replicas must always discard messages as the pairwise channels are ordered so a replica may need to discard an out-of-date message to process a more recent one
 DiscardMessages ==
     /\ \E s,r \in R:
-            network' = [network EXCEPT ![r][s] = SelectSeq(@, LAMBDA m: m.view >= view[r])]
+            network' = [network EXCEPT ![r][s] = SelectSeq(@, LAMBDA m: ~(m.view < view[r] \/ (m.view = view[r] /\ m.type = "ViewChange" /\ primary[r])))]
     /\ UNCHANGED <<view, log, primary, prepareQC, crashCommitIndex, byzCommitIndex, byzActions, viewStable>>
 
 ----


### PR DESCRIPTION
Otherwise, there is a high likelihood of the generated behaviors ending in a suffix of Timeout and DiscardMessage action.  This situation arises when there is no primary replica, and Timeout and DiscardMessage are the only enabled actions. For the BecomePrimary action to become enabled for some replicas, multiple DiscardMessage actions must occur. However, the simulation may frequently schedule a Timeout action in between, leading to additional DiscardMessage steps, prolonging the process unnecessarily.