### PR TITLE
ci: build and upload spec PDF

### DIFF
--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -9,6 +9,23 @@ on:
 
 jobs:
 
+  build-spec-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get (nightly) TLA+ Tools
+        run: wget https://nightly.tlapl.us/dist/tla2tools.jar
+      - name: Install LaTeX
+        run: sudo apt-get install --yes texlive-latex-recommended
+      - name: Build pretty-printed specification
+        run: java -cp tla2tools.jar tla2tex.TLA -number -nops -latexCommand pdflatex -out pirateship pirateship.tla
+      - name: Upload specification PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: PirateShip TLA+ specification
+          path: pirateship.pdf
+          if-no-files-found: error
+
   tlc-simulate:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- add an independent CI job that pretty-prints `pirateship.tla` with line numbers
- build `pirateship.pdf` using TLATeX and pdfLaTeX
- upload the PDF as a workflow artifact and fail if it is missing

## Validation
- parsed the workflow YAML successfully
- ran `git diff --check`
- ran the exact TLATeX build command locally and verified the resulting 15-page A4 PDF