### PR TITLE
Validate NewView messages come from the designated primary

### DIFF
--- a/pirateship.tla
+++ b/pirateship.tla
@@ -305,6 +305,8 @@ ReceiveNewView(r, p) ==
     /\ network[r][p] # <<>>
     \* and the next message is a NewView
     /\ Head(network[r][p]).type = "NewView"
+    \* and the message must be from the designated primary
+    /\ p = Primary(Head(network[r][p]).view)
     \* the replica must be in the same view or lower
     /\ view[r] \leq Head(network[r][p]).view
     \* received log must be well formed


### PR DESCRIPTION
## Summary
- require `NewView` messages to originate from the primary designated for the announced view
- align receiver validation with the PirateShip paper's view-change protocol

## Validation
- `git diff --check`
- TLC not run locally because Java and the TLA+ JARs are unavailable in this workspace; the repository workflow will run the configured model checks